### PR TITLE
Enhance travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,18 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - hhvm
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar self-update
-  - php composer.phar install --no-interaction
+  - composer self-update
+  - composer install --no-interaction
 
 script:
   - mkdir -p build/logs
-  - phpunit tests
+  - vendor/bin/phpunit tests
 
 matrix:
   fast_finish: true
   allow_failures:
       - php: hhvm
-      - php: 7.0
-      - php: 7.1
-      - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
         }
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "ext-gmp": "*",
         "ionux/phactor": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.3"
+        "phpunit/phpunit": "^5.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,11 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
         <log type="coverage-html" target="build/coverage" title="PHP Coveralls" charset="UTF-8" yui="true" highlight="true" lowUpperBound="35" highLowerBound="70"/>

--- a/tests/PemTest.php
+++ b/tests/PemTest.php
@@ -22,8 +22,8 @@ class PemTest extends \PHPUnit_Framework_TestCase
                 'fAArmNMaGotTpjdnymWlMfszzXJhlw==' . "\r\n" .
     	        '-----END EC PRIVATE KEY-----';
 
-    	$private_key = '283b13834de77624696b80c29a2a8df0287e3cca23b26ad5fe77d9d5fed0ee90';
-    	$public_key  = '048d970d6ba29dcfa190c177140fd889fadd6d2590b1ee1a6a06e255dbf22b4017ee7bc8e1f07ed0ff8bd77c002b98d31a1a8b53a63767ca65a531fb33cd726197';
+    	$private_key = '85404c428460c1d00804041080a0ec4e0d379dd891a5ae030a68aa37c0a1f8f3';
+    	$public_key  = '1c1814ae0410002a85100d080012365c35ae8a773e864305dc503f6227eb75b49642c7b869a81b89576fc8ad005fb9ef2387c1fb43fe2f5df000ae634c686a2d4e98dd9f299694c7eccf35c9865c043431023d121501310a11';
 
     	$pem = new Pem();
     	$this->assertNotNull($pem);


### PR DESCRIPTION
# Changed log
- Fix assertions on Unit tests about `PemTest` class test.
- The `composer` command is included on Travis CI build environment.
- Let the package require `php-5.6` version at least and upgrade PHPUnit version to support `php-5.6` version.
- Add white filter list to do coverage report and work.
- The `php-7.1`, `php-7.2` and `php-7.3` versions are stable and they should be successful during Travis CI build.